### PR TITLE
v0.2.0: Minor API changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webweg"
-version = "0.1.2"
+version = "0.2.0"
 edition = "2021"
 description = "An asynchronous API wrapper for UCSD's WebReg course enrollment system."
 

--- a/src/webreg_clean_defn.rs
+++ b/src/webreg_clean_defn.rs
@@ -151,7 +151,7 @@ impl ToString for Meeting {
 #[derive(Debug, Clone, Serialize)]
 pub struct ScheduledSection {
     /// The section number, for example `79903`.
-    pub section_number: i64,
+    pub section_number: String,
     /// The subject code. For example, if this represents `CSE 100`, then this would be `CSE`.
     pub subject_code: String,
     /// The subject code. For example, if this represents `CSE 100`, then this would be `100`.

--- a/src/webreg_raw_defn.rs
+++ b/src/webreg_raw_defn.rs
@@ -145,13 +145,13 @@ pub struct RawWebRegMeeting {
     pub needs_waitlist: String,
 }
 
-/// A meeting that you have enrolled in.. Note that this doesn't represent a class by itself, but
+/// A meeting that you have enrolled in. Note that this doesn't represent a class by itself, but
 /// rather a "piece" of that class. For example, one `ScheduledMeeting` can represent a discussion
 /// while another can represent a lecture. Additionally, each `ScheduledMeeting` can only represent
 /// one meeting per week (so, for example, a MWF lecture would have 3 entries).
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RawScheduledMeeting {
-    /// Number of units that this class is being taken for (e.g. 4.00)
+    /// The section number. Each section has a unique number identifier.
     #[serde(rename = "SECTION_HEAD")]
     pub section_number: i64,
 


### PR DESCRIPTION
- `ScheduledSection#section_number` is now a `String` (not a `i64`).
- `WebRegWrapper#new_with_client` added
- `WebRegWrapper#change_grading_option` parameters changed (i64 and &str to &str and enum)
- `SearchRequestBuilder#apply_days` takes an enum instead of u32