### PR TITLE
v0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webweg"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 description = "An asynchronous API wrapper for UCSD's WebReg course enrollment system."
 

--- a/README.md
+++ b/README.md
@@ -55,12 +55,13 @@ if you want to perform continuous requests.
 ## Walkthrough
 To use the wrapper, you need to create a new instance of it. For example:
 ```rs
+use reqwest::Client;
 use webweg::webreg_wrapper::WebRegWrapper;
 
 let term = "SP22";
 // For authentication cookies, see previous section.
 let cookie = "your authentication cookies here";
-let w = WebRegWrapper::new(cookie.to_string(), term);
+let w = WebRegWrapper::new(Client::new() cookie.to_string(), term);
 ```
 
 Once created, you're able to use the various wrapper functions. Some useful 
@@ -173,10 +174,10 @@ schedule. You can use the following code:
 let res = w.add_to_plan(PlanAdd {
     subject_code: "CSE",
     course_code: "100",
-    section_number: "079911",
+    section_id: "079911",
     section_code: "A01",
     // Using S/U grading.
-    grading_option: Some("S"),
+    grading_option: Some(GradeOption::S),
     // Put in default schedule
     schedule_name: None,
     unit_count: 4
@@ -228,7 +229,7 @@ let add_res = w
     .add_section(
         section_res[0].has_seats(),
         EnrollWaitAdd {
-            section_number: "078616",
+            section_id: "078616",
             // Use default grade option
             grading_option: None,
             // Use default unit count
@@ -256,7 +257,7 @@ let course_to_drop = w
     .await
     .unwrap_or_else(|_| vec![])
     .into_iter()
-    .find(|x| x.section_number == 78616);
+    .find(|x| x.section_id == 78616);
 
 // Check if we're enrolled in this course
 let is_enrolled = if let Some(r) = course_to_drop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,12 +55,13 @@
 //! ## Walkthrough
 //! To use the wrapper, you need to create a new instance of it. For example:
 //! ```rs
+//! use reqwest::Client;
 //! use webweg::webreg_wrapper::WebRegWrapper;
 //!
 //! let term = "SP22";
 //! // For authentication cookies, see previous section.
 //! let cookie = "your authentication cookies here";
-//! let w = WebRegWrapper::new(cookie.to_string(), term);
+//! let w = WebRegWrapper::new(Client::new(), cookie.to_string(), term);
 //! ```
 //!
 //! Once created, you're able to use the various wrapper functions. Some useful
@@ -173,7 +174,7 @@
 //! let res = w.add_to_plan(PlanAdd {
 //!     subject_code: "CSE",
 //!     course_code: "100",
-//!     section_number: "079911",
+//!     section_id: "079911",
 //!     section_code: "A01",
 //!     // Using S/U grading.
 //!     grading_option: Some("S"),
@@ -206,7 +207,7 @@
 //! sections.
 //!
 //! Example: Suppose we wanted to enroll or waitlist a section of Math 184 with
-//! section number `078616`, and then drop it afterwards. This is how we could
+//! section ID `078616`, and then drop it afterwards. This is how we could
 //! do this.
 //!
 //! ```rs
@@ -228,7 +229,7 @@
 //!     .add_section(
 //!         section_res[0].has_seats(),
 //!         EnrollWaitAdd {
-//!             section_number: "078616",
+//!             section_id: "078616",
 //!             // Use default grade option
 //!             grading_option: None,
 //!             // Use default unit count
@@ -256,7 +257,7 @@
 //!     .await
 //!     .unwrap_or_else(|_| vec![])
 //!     .into_iter()
-//!     .find(|x| x.section_number == 78616);
+//!     .find(|x| x.section_id == 78616);
 //!
 //! // Check if we're enrolled in this course
 //! let is_enrolled = if let Some(r) = course_to_drop {
@@ -311,3 +312,5 @@ mod webreg_helper;
 pub mod webreg_clean_defn;
 pub mod webreg_raw_defn;
 pub mod webreg_wrapper;
+
+pub use reqwest;

--- a/src/webreg_clean_defn.rs
+++ b/src/webreg_clean_defn.rs
@@ -145,7 +145,7 @@ impl Meeting {
         s.push_str(&format!("{} {}", self.building, self.room));
 
         s.push_str("..");
-        s.push_str(&format!("{}", self.other_instructors.join(" & ")));
+        s.push_str(&self.other_instructors.join(" & "));
 
         s
     }
@@ -179,8 +179,8 @@ impl ToString for Meeting {
 /// are enrolled in, waitlisted for, or planned.
 #[derive(Debug, Clone, Serialize)]
 pub struct ScheduledSection {
-    /// The section number, for example `79903`.
-    pub section_number: String,
+    /// The section ID, for example `79903`.
+    pub section_id: String,
     /// The subject code. For example, if this represents `CSE 100`, then this would be `CSE`.
     pub subject_code: String,
     /// The subject code. For example, if this represents `CSE 100`, then this would be `100`.
@@ -223,7 +223,7 @@ impl ToString for ScheduledSection {
         let mut s = format!(
             "[{} / {}] {} ({} {}) with {} - {} ({} Units, {} Grading, Avail.: {}, Enroll.: {}, Total: {})\n",
             self.section_code,
-            self.section_number,
+            self.section_id,
             self.course_title,
             self.subject_code,
             self.course_code,

--- a/src/webreg_raw_defn.rs
+++ b/src/webreg_raw_defn.rs
@@ -60,9 +60,9 @@ pub struct RawWebRegMeeting {
     #[serde(rename = "SCTN_ENRLT_QTY")]
     pub enrolled_count: i64,
 
-    /// The section number. Each section has a unique number identifier.
+    /// The section ID. Each section has a unique number identifier.
     #[serde(rename = "SECTION_NUMBER")]
-    pub section_number: String,
+    pub section_id: String,
 
     /// The number of students currently on the waitlist.
     #[serde(rename = "COUNT_ON_WAITLIST")]
@@ -151,9 +151,9 @@ pub struct RawWebRegMeeting {
 /// one meeting per week (so, for example, a MWF lecture would have 3 entries).
 #[derive(Serialize, Deserialize, Debug)]
 pub struct RawScheduledMeeting {
-    /// The section number. Each section has a unique number identifier.
+    /// The section ID. Each section has a unique number identifier.
     #[serde(rename = "SECTION_HEAD")]
-    pub section_number: i64,
+    pub section_id: i64,
 
     /// Number of units that this class is being taken for (e.g. 4.00)
     #[serde(rename = "SECT_CREDIT_HRS")]

--- a/tests/wrapper_tests.rs
+++ b/tests/wrapper_tests.rs
@@ -1,5 +1,6 @@
 extern crate core;
 
+use reqwest::Client;
 use std::collections::HashSet;
 use std::time::Duration;
 use tokio::time;
@@ -29,7 +30,7 @@ fn get_cookie_str() -> String {
 /// `math 10b`.
 #[tokio::test]
 async fn test_get_course_info() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     let math_155a = wrapper.get_course_info("math", "155a").await;
@@ -52,8 +53,8 @@ async fn test_get_course_info() {
     assert_eq!(36, math_155a[1].total_seats);
     // The professor teaching it is Sam, Steven V.
     assert_eq!(vec!["Buss, Samuel R".to_string()], math_155a[0].instructors);
-    // There are three meetings -- a lecture, discussion, and final
-    assert_eq!(3, math_155a[0].meetings.len());
+    // There are five meetings -- a lecture, discussion, final, and 2 review sessions
+    assert_eq!(5, math_155a[0].meetings.len());
 
     // Test the second section.
     let lecture = math_155a[1]
@@ -123,7 +124,7 @@ async fn test_get_course_info() {
 async fn test_instructor() {
     // Literally hours after I made this test, WebReg removed "Staff" from the courses I selected.
     // Nice.
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     let cse_130 = wrapper.get_course_info("cse", "130").await;
@@ -148,7 +149,7 @@ async fn test_instructor() {
 /// This function tests the `search_courses_detailed()` method with one section.
 #[tokio::test]
 async fn test_search_one_sec() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     // Search for 1 section: Math 184 (078615)
@@ -188,7 +189,7 @@ async fn test_search_one_sec() {
 /// This function tests the `search_courses_detailed()` method with multiple sections.
 #[tokio::test]
 async fn test_search_mult_sec() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     // Search for 3 sections:
@@ -238,7 +239,7 @@ async fn test_search_mult_sec() {
 /// This function tests the `search_courses_detailed()` method with advanced search features.
 #[tokio::test]
 async fn test_adv_search() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     // Filter all courses by:
@@ -278,7 +279,7 @@ async fn test_adv_search() {
 /// will need to manually check for themselves.
 #[tokio::test]
 async fn test_get_schedule() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     let schedule = wrapper.get_schedule(None).await;
@@ -304,7 +305,7 @@ async fn test_get_schedule() {
 #[tokio::test]
 #[ignore = "Don't need to spam WebReg here."]
 async fn test_change_grade_options() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     // Try to change grading option to P for a class that we're enrolled in.
@@ -345,7 +346,7 @@ async fn test_change_grade_options() {
 /// time.
 #[tokio::test]
 async fn test_other_instructors() {
-    let wrapper = WebRegWrapper::new(get_cookie_str(), TERM);
+    let wrapper = WebRegWrapper::new(Client::new(), get_cookie_str(), TERM);
     assert!(wrapper.is_valid().await);
 
     let cse_30 = wrapper.get_course_info("cse", "30").await;


### PR DESCRIPTION
- lots of examples added to docs in wrapper
- changed `section_number` to `section_id` wherever possible
- used enum to enforce grade option type
- export `reqwest`
- require users to provide a `reqwest::Client` for the wrapper