### PR TITLE
v0.7.4: Fix Enrollment Status Not Deserializing Correctly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webweg"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "An asynchronous API wrapper for UCSD's WebReg course enrollment system."
 readme = "README.md"

--- a/src/types.rs
+++ b/src/types.rs
@@ -212,8 +212,8 @@ impl ToString for ScheduledSection {
     fn to_string(&self) -> String {
         let status: Cow<'_, str> = match self.enrolled_status {
             EnrollmentStatus::Enrolled => "Enrolled".into(),
-            EnrollmentStatus::Waitlist(r) => {
-                format!("Waitlisted {}/{}", r, self.waitlist_ct).into()
+            EnrollmentStatus::Waitlist { waitlist_pos } => {
+                format!("Waitlisted {}/{}", waitlist_pos, self.waitlist_ct).into()
             }
             EnrollmentStatus::Planned => "Planned".into(),
             EnrollmentStatus::Unknown => "Unknown".into(),
@@ -246,10 +246,10 @@ impl ToString for ScheduledSection {
 
 /// An enum that represents your enrollment status.
 #[derive(Debug, Clone, Serialize)]
-#[serde(untagged)]
+#[serde(tag = "enroll_status")]
 pub enum EnrollmentStatus {
     Enrolled,
-    Waitlist(i64),
+    Waitlist { waitlist_pos: i64 },
     Planned,
     Unknown,
 }


### PR DESCRIPTION
The `enrollment_status` property used serde's `untagged` deserializing rule, which caused the enrollment status in the schedule to be lost when deserializing the schedule object to JSON. 